### PR TITLE
Tidying Branch Duals Implementation

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -355,6 +355,10 @@ Adds the (upper and lower) thermal limit constraints for the desired branch to t
 
 """
 function constraint_thermal_limit_from(pm::GenericPowerModel, n::Int, i::Int)
+    if !haskey(pm.con[:nw][n], :sm_fr)
+        pm.con[:nw][n][:sm_fr] = Dict{Int,Any}() # note this can be a constraint or variable
+    end
+
     branch = ref(pm, n, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -366,6 +370,10 @@ constraint_thermal_limit_from(pm::GenericPowerModel, i::Int) = constraint_therma
 
 ""
 function constraint_thermal_limit_to(pm::GenericPowerModel, n::Int, i::Int)
+    if !haskey(pm.con[:nw][n], :sm_to)
+        pm.con[:nw][n][:sm_to] = Dict{Int,Any}() # note this can be a constraint or variable
+    end
+
     branch = ref(pm, n, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -216,6 +216,9 @@ function _make_per_unit(data::Dict{String,Any}, mva_base::Real)
         apply_func(branch, "pt", rescale)
         apply_func(branch, "qf", rescale)
         apply_func(branch, "qt", rescale)
+
+        apply_func(branch, "mu_sm_fr", rescale_dual)
+        apply_func(branch, "mu_sm_to", rescale_dual)
     end
 
     for dcline in dclines
@@ -322,6 +325,9 @@ function _make_mixed_units(data::Dict{String,Any}, mva_base::Real)
         apply_func(branch, "pt", rescale)
         apply_func(branch, "qf", rescale)
         apply_func(branch, "qt", rescale)
+
+        apply_func(branch, "mu_sm_fr", rescale_dual)
+        apply_func(branch, "mu_sm_to", rescale_dual)
     end
 
     for dcline in dclines

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -147,7 +147,7 @@ end
 
 "`-rate_a <= p[f_idx] <= rate_a`"
 function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a)
-    p_fr = pm.var[:nw][n][:p][f_idx]
+    p_fr = pm.con[:nw][n][:sm_fr][f_idx[1]] = pm.var[:nw][n][:p][f_idx]
     getlowerbound(p_fr) < -rate_a && setlowerbound(p_fr, -rate_a)
     getupperbound(p_fr) > rate_a && setupperbound(p_fr, rate_a)
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -3,23 +3,34 @@
 function compare_dict(d1, d2)
     for (k1,v1) in d1
         if !haskey(d2, k1)
-            #@test false
+            #println(k1)
             return false
         end
         v2 = d2[k1]
 
         if isa(v1, Number)
-            #@test isapprox(v1, v2)
-            if !isapprox(v1, v2)
-                return false
+            if isnan(v1)
+                #println("1.1")
+                if !isnan(v2)
+                    #println(v1, " ", v2)
+                    return false
+                end
+            else
+                #println("1.2")
+                if !isapprox(v1, v2)
+                    #println(v1, " ", v2)
+                    return false
+                end
             end
         elseif isa(v1, Dict)
             if !compare_dict(v1, v2)
+                #println(v1, " ", v2)
                 return false
             end
         else
-            #@test v1 == v2
+            #println("2")
             if v1 != v2
+                #println(v1, " ", v2)
                 return false
             end
         end

--- a/test/data.jl
+++ b/test/data.jl
@@ -57,6 +57,18 @@
 
         @test compare_dict(result, result_base)
     end
+
+
+    @testset "5-bus case solution with duals" begin
+        result = run_dc_opf("../test/data/case5.m", ipopt_solver, setting = Dict("output" => Dict("branch_flows" => true, "duals" => true)))
+        result_base = deepcopy(result)
+
+        PowerModels.make_mixed_units(result["solution"])
+        PowerModels.make_per_unit(result["solution"])
+
+        @test compare_dict(result, result_base)
+    end
+
 end
 
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -350,21 +350,3 @@ end
     end
 end
 
-@testset "Dual variables from OPF" begin
-    settingdict = Dict("output" => Dict("duals" => true))
-    result = run_dc_opf("../test/data/case14.m", ipopt_solver, setting = settingdict)
-    PowerModels.make_mixed_units(result["solution"])
-    @testset "KCL dual variables" begin
-        res = result["solution"]["bus"]
-        for b in keys(res)
-            @test haskey(res[b], "lam_kcl_i")
-            @test haskey(res[b], "lam_kcl_r")
-            @test round(res[b]["lam_kcl_r"], 2) == -39.02 # Expected result for case14
-        end
-    end
-
-    @testset "Thermal limits dual variables" begin
-        @test haskey(result["solution"], "branch_duals")
-        @test length(keys(result["solution"]["branch_duals"]["0"])) == 20
-    end
-end

--- a/test/output.jl
+++ b/test/output.jl
@@ -68,6 +68,27 @@ end
 end
 
 
+@testset "test dual value output" begin
+    settings = Dict("output" => Dict("duals" => true))
+    result = run_dc_opf("../test/data/case14.m", ipopt_solver, setting = settings)
+
+    PowerModels.make_mixed_units(result["solution"])
+    @testset "kcl duals" begin
+        bus_result = result["solution"]["bus"]
+        for (i, bus) in bus_result
+            @test haskey(bus, "lam_kcl_r")
+            @test haskey(bus, "lam_kcl_i")
+            @test isapprox(bus["lam_kcl_r"], -39.02; atol = 1e-2) # Expected result for case14
+        end
+    end
+
+    @testset "thermal limit duals" begin
+        @test haskey(result["solution"], "branch_duals")
+        @test length(keys(result["solution"]["branch_duals"]["0"])) == 20
+    end
+end
+
+
 # recomended by @lroald
 @testset "test solution feedback" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,4 +43,3 @@ include("tnep.jl")
 include("multinetwork.jl")
 
 include("docs.jl")
-


### PR DESCRIPTION
Just some minor clean up.  If you are happy with this then merge it into your fork and then I will merge that into master.

- removed `add_sm_duals` in favor of the more generic `add_duals`
- moved branch dual values into `solution:branch` rather than `solution:branch_duals`
- added branch dual units transformation
- moved dual output tests from the opf tests to the output tests
- added dual value tests on case5.m, because it has non-zero values on branches
- added duals to idempotent unit transformation tests
